### PR TITLE
Zlib removed to make module compile

### DIFF
--- a/npm_Code/package.json
+++ b/npm_Code/package.json
@@ -24,7 +24,6 @@
     "moment": "^2.17.1",
     "mongodb": "^3.0.1",
     "promise": "^8.0.1",
-    "zlib": "^1.0.5",
     "tedious": "^2.0.0",
     "documentdb": "^1.13.0"
   },


### PR DESCRIPTION
Module doesn't compile on Node 7.9.0, NPM 4.2.0.

This is because zlib has been removed from node project since version 6.2.1. Zlib's removal from dependencies will make the botbuilder-mongodb module compile.