### PR TITLE
Use new url parser for mongodb

### DIFF
--- a/npm_Code/lib/MongoDbClient.js
+++ b/npm_Code/lib/MongoDbClient.js
@@ -8,7 +8,7 @@ var MongoDbClient = (function () {
     MongoDbClient.prototype.initialize = function (callback) {
         var _this = this;
         var uri = "mongodb://" + this.options.ip + ":" + this.options.port + "/" + this.options.queryString;
-        var connectOptions = {};
+        var connectOptions = { useNewUrlParser: true };
         if (this.options.username && this.options.password) {
             connectOptions.auth = {};
             connectOptions.auth.user = this.options.username;


### PR DESCRIPTION
Eliminates this warning:

```
(node:23) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
```